### PR TITLE
added further exception type when reading cache

### DIFF
--- a/resources/lib/composite_addon/addon/cache_control.py
+++ b/resources/lib/composite_addon/addon/cache_control.py
@@ -83,7 +83,7 @@ class CacheControl:
                           (cache_name, cache_data.decode('utf-8', 'ignore')))
             try:
                 cache_object = pickle.loads(cache_data)
-            except TypeError:
+            except (ValueError, TypeError):
                 return False, None
             return True, cache_object
 


### PR DESCRIPTION
If you switch back from Python 3 to 2, TypeError may be thrown.